### PR TITLE
Update throw* to handle nil and empty list argument

### DIFF
--- a/src/doric/core.clj
+++ b/src/doric/core.clj
@@ -130,7 +130,7 @@
 
 (defn table*
   ([rows]
-     (table* (vary-meta (keys (first rows))
+     (table* (vary-meta (or (keys (first rows)) [])
                         merge (meta rows)) rows))
   ([cols rows]
      (let [meta (meta cols)

--- a/test/doric/test/core.clj
+++ b/test/doric/test/core.clj
@@ -105,3 +105,12 @@
                          {:name :2 :format inc :width 0}]
                         [{:1 3 :2 4}])]
         (is (= 0 @calls))))))
+
+(deftest test-empty-table
+  (let [empty-table "|--|\n|  |\n|--|\n|--|"]
+    (is (= empty-table (table [])))
+    (is (= empty-table (table nil)))
+    (is (= empty-table (table [] [])))
+    (is (= empty-table (table [] nil)))
+    (is (= empty-table (table nil [])))
+    (is (= empty-table (table nil nil)))))


### PR DESCRIPTION
Was throwing a NPE in the single arity when given an empty list or nil.

Added tests.
